### PR TITLE
Add superclass initialization and __hash__ function

### DIFF
--- a/lib/evernote/edam/error/ttypes.py
+++ b/lib/evernote/edam/error/ttypes.py
@@ -245,7 +245,6 @@ class EDAMSystemException(TException):
    - message
    - rateLimitDuration
   """
-
   thrift_spec = (
     None, # 0
     (1, TType.I32, 'errorCode', None, None, ), # 1
@@ -254,9 +253,11 @@ class EDAMSystemException(TException):
   )
 
   def __init__(self, errorCode=None, message=None, rateLimitDuration=None,):
+    TException.__init__(self, message)
     self.errorCode = errorCode
     self.message = message
     self.rateLimitDuration = rateLimitDuration
+
 
   def read(self, iprot):
     if iprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None and fastbinary is not None:
@@ -321,11 +322,13 @@ class EDAMSystemException(TException):
       for key, value in self.__dict__.items()]
     return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
 
+  def __hash__(self):
+    return hash((self.__class__, tuple(self.__dict__.items())))
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
   def __ne__(self, other):
     return not (self == other)
+
 
 class EDAMNotFoundException(TException):
   """
@@ -353,6 +356,7 @@ class EDAMNotFoundException(TException):
   )
 
   def __init__(self, identifier=None, key=None,):
+    TException.__init__(self)
     self.identifier = identifier
     self.key = key
 
@@ -407,6 +411,9 @@ class EDAMNotFoundException(TException):
     L = ['%s=%r' % (key, value)
       for key, value in self.__dict__.items()]
     return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+
+  def __hash__(self):
+    return hash((self.__class__, tuple(self.__dict__.items())))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__

--- a/lib/evernote/edam/type/ttypes.py
+++ b/lib/evernote/edam/type/ttypes.py
@@ -403,6 +403,9 @@ class Data(object):
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
+  def __hash__(self):
+    return hash((self.__class__, tuple(self.__dict__.items())))
+
   def __ne__(self, other):
     return not (self == other)
 
@@ -1020,6 +1023,9 @@ class UserAttributes(object):
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
+  def __hash__(self):
+    return hash((self.__class__, tuple(self.__dict__.items())))
+
   def __ne__(self, other):
     return not (self == other)
 
@@ -1432,6 +1438,9 @@ class Accounting(object):
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
+  def __hash__(self):
+    return hash((self.__class__, tuple(self.__dict__.items())))
+
   def __ne__(self, other):
     return not (self == other)
 
@@ -1548,6 +1557,9 @@ class BusinessUserInfo(object):
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+  def __hash__(self):
+    return hash((self.__class__, tuple(self.__dict__.items())))
 
   def __ne__(self, other):
     return not (self == other)
@@ -1792,6 +1804,9 @@ class PremiumInfo(object):
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+  def __hash__(self):
+    return hash((self.__class__, tuple(self.__dict__.items())))
 
   def __ne__(self, other):
     return not (self == other)
@@ -2130,6 +2145,9 @@ class User(object):
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
+  def __hash__(self):
+    return hash((self.__class__, tuple(self.__dict__.items())))
+
   def __ne__(self, other):
     return not (self == other)
 
@@ -2271,6 +2289,9 @@ class Tag(object):
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
+  def __hash__(self):
+    return hash((self.__class__, tuple(self.__dict__.items())))
+
   def __ne__(self, other):
     return not (self == other)
 
@@ -2388,6 +2409,9 @@ class LazyMap(object):
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+  def __hash__(self):
+    return hash((self.__class__, tuple(self.__dict__.items())))
 
   def __ne__(self, other):
     return not (self == other)
@@ -2661,6 +2685,9 @@ class ResourceAttributes(object):
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+  def __hash__(self):
+    return hash((self.__class__, tuple(self.__dict__.items())))
 
   def __ne__(self, other):
     return not (self == other)
@@ -2937,6 +2964,9 @@ class Resource(object):
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+  def __hash__(self):
+    return hash((self.__class__, tuple(self.__dict__.items())))
 
   def __ne__(self, other):
     return not (self == other)
@@ -3405,6 +3435,9 @@ class NoteAttributes(object):
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
+  def __hash__(self):
+    return hash((self.__class__, tuple(self.__dict__.items())))
+
   def __ne__(self, other):
     return not (self == other)
 
@@ -3787,6 +3820,9 @@ class Note(object):
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
+  def __hash__(self):
+    return hash((self.__class__, tuple(self.__dict__.items())))
+
   def __ne__(self, other):
     return not (self == other)
 
@@ -3923,6 +3959,9 @@ class Publishing(object):
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
+  def __hash__(self):
+    return hash((self.__class__, tuple(self.__dict__.items())))
+
   def __ne__(self, other):
     return not (self == other)
 
@@ -4035,6 +4074,9 @@ class BusinessNotebook(object):
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
+  def __hash__(self):
+    return hash((self.__class__, tuple(self.__dict__.items())))
+
   def __ne__(self, other):
     return not (self == other)
 
@@ -4134,6 +4176,9 @@ class SavedSearchScope(object):
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+  def __hash__(self):
+    return hash((self.__class__, tuple(self.__dict__.items())))
 
   def __ne__(self, other):
     return not (self == other)
@@ -4310,6 +4355,9 @@ class SavedSearch(object):
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
+  def __hash__(self):
+    return hash((self.__class__, tuple(self.__dict__.items())))
+
   def __ne__(self, other):
     return not (self == other)
 
@@ -4408,6 +4456,9 @@ class SharedNotebookRecipientSettings(object):
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+  def __hash__(self):
+    return hash((self.__class__, tuple(self.__dict__.items())))
 
   def __ne__(self, other):
     return not (self == other)
@@ -4674,6 +4725,9 @@ class SharedNotebook(object):
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+  def __hash__(self):
+    return hash((self.__class__, tuple(self.__dict__.items())))
 
   def __ne__(self, other):
     return not (self == other)
@@ -5065,6 +5119,9 @@ class NotebookRestrictions(object):
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
+  def __hash__(self):
+    return hash((self.__class__, tuple(self.__dict__.items())))
+
   def __ne__(self, other):
     return not (self == other)
 
@@ -5422,6 +5479,9 @@ class Notebook(object):
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
+  def __hash__(self):
+    return hash((self.__class__, tuple(self.__dict__.items())))
+
   def __ne__(self, other):
     return not (self == other)
 
@@ -5674,6 +5734,9 @@ class LinkedNotebook(object):
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
+  def __hash__(self):
+    return hash((self.__class__, tuple(self.__dict__.items())))
+
   def __ne__(self, other):
     return not (self == other)
 
@@ -5809,6 +5872,9 @@ class NotebookDescriptor(object):
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+  def __hash__(self):
+    return hash((self.__class__, tuple(self.__dict__.items())))
 
   def __ne__(self, other):
     return not (self == other)


### PR DESCRIPTION
See here more details why it's important to have it in general:
https://docs.python.org/3/reference/datamodel.html#object.__hash__

> if [a class] defines **eq**() but not **hash**(), its instances will not be
> usable as items in hashable collections.

In particular, python's standard `traceback` module relies on hashability of exceptions.

``` python
>>> from evernote.edam.error.ttypes import *
>>> import traceback
>>> try: raise EDAMSystemException()
... except: traceback.print_exc()
... 
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
  File "/usr/lib/python3.4/traceback.py", line 252, in print_exc
    print_exception(*sys.exc_info(), limit=limit, file=file, chain=chain)
  File "/usr/lib/python3.4/traceback.py", line 169, in print_exception
    for line in _format_exception_iter(etype, value, tb, limit, chain):
  File "/usr/lib/python3.4/traceback.py", line 146, in _format_exception_iter
    for value, tb in values:
  File "/usr/lib/python3.4/traceback.py", line 123, in _iter_chain
    seen.add(exc)
TypeError: unhashable type: 'EDAMSystemException'
```
