### PR TITLE
Replaces \n to avoid bad HTTP header

### DIFF
--- a/lib/evernote/api/client.py
+++ b/lib/evernote/api/client.py
@@ -139,7 +139,7 @@ class Store(object):
         http_client.setCustomHeaders({
             'User-Agent': "%s / %s; Python / %s;"
                           % (
-                self._user_agent_id, self._get_sdk_version(), sys.version)
+                self._user_agent_id, self._get_sdk_version(), sys.version.replace("\n", ""))
         })
 
         thrift_protocol = TBinaryProtocol.TBinaryProtocol(http_client)


### PR DESCRIPTION
Certain environments may produce a multi-line `sys.version` which breaks the custom `User-Agent` header.

E.g. `sys.version` as `Python / 3.5.0 (default, Oct 24 2015, 09:48:42) \n[GCC 4.9.2]`

This results in an illegal HTTP header of...

```
User-Agent: evernote_user:V=2 1.25; Python / 3.5.0 (default, Oct 24 2015, 09:48:42)
[GCC 4.9.2]
```

This p/r replaces the `'\n'` character with `''` to ensure a valid, one-line HTTP header. E.g.:

```
User-Agent: evernote_user:V=2 1.25; Python / 3.5.0 (default, Oct 24 2015, 09:48:42) [GCC 4.9.2]
```

See https://github.com/evernote/evernote-sdk-python/issues/34