### PR TITLE
Temp fix for duplicate header failures 

### DIFF
--- a/lib/thrift/transport/THttpClient.py
+++ b/lib/thrift/transport/THttpClient.py
@@ -125,7 +125,7 @@ class THttpClient(TTransportBase):
     self.__wbuf = BytesIO()
 
     # HTTP request
-    self.__http.putrequest('POST', self.path)
+    self.__http.putrequest('POST', self.path, skip_host=True)
 
     # Write headers
     self.__http.putheader('Host', self.host)


### PR DESCRIPTION
Duplicate headers are causing failures in this SDK as of a recent server upgrade (related to RFC 7230)

This is a potential temporary solution until an upgrade of Thrift can be prioritized

Issue #27 