### PR TITLE
fix a bug that set sandbox host while using Chinese yinxiang service …

### DIFF
--- a/lib/evernote/api/client.py
+++ b/lib/evernote/api/client.py
@@ -23,11 +23,15 @@ class EvernoteClient(object):
         self.sandbox = options.get('sandbox', True)
         self.china = options.get('china', False)
         if self.sandbox:
-            default_service_host = 'sandbox.evernote.com'
-        elif self.china:
-            default_service_host = 'app.yinxiang.com'
+            if self.china:
+                default_service_host = 'sandbox.yinxiang.com'
+            else:
+                default_service_host = 'sandbox.evernote.com'
         else:
-            default_service_host = 'www.evernote.com'
+            if self.china:
+                default_service_host = 'app.yinxiang.com'
+            else:
+                default_service_host = 'www.evernote.com'
         self.service_host = options.get('service_host', default_service_host)
         self.additional_headers = options.get('additional_headers', {})
         self.token = options.get('token')


### PR DESCRIPTION
## env of bug occured
MacOS 10.15.5
Python 3.7.6
evernote-sdk-python3 master branch

## bug description
I'm located in China, I need to use sandbox service of yinxiang. When I run simple test code from this repo, I got an exception about auth.

Below is my step by step to reproduce this bug.

- step 1: clone this repo

<pre>git clone git@github.com:evernote/evernote-sdk-python3.git`</pre>

- step 2: create venv

<pre>
cd evernote-sdk-python3
virtualenv venv
source venv/bin/activate
</pre>

- step 3: install this repo into external libs

<pre>python3 setup.py install</pre>

- step 4: create simple code

create a new file named YinxiangTest.py 

<pre>
# -*- coding:utf-8 -*-

from evernote.api.client import EvernoteClient
from evernote.edam.notestore import NoteStore

dev_token = "my dev token of yinxiang"
# crate EvernoteClient object by dev token
client = EvernoteClient(token=dev_token, sandbox=True, china=True)
# get user of Store object
userStore = client.get_user_store()
# get user info
user = userStore.getUser()
print("user id -> %s" % user.id)
print("username -> %s" % user.username)

noteStore = client.get_note_store()
# create NoteFilter object
note_filter = NoteStore.NoteFilter()
# get all of notebooks
notebooks = noteStore.listNotebooks()
for notebook in notebooks:
    # get guid of notebook
    notebook_guid = notebook.guid
    # get name of notebook
    notebook_name = notebook.name
    print("notebook guid -> %s" % notebook_guid)
    print("notebook name -> %s" % notebook_name)
    # set filter of notebook of guid
    note_filter.notebookGuid = notebook_guid
    for note in noteStore.findNotes(dev_token, note_filter, 0, 999).notes:
        print("note guid -> %s " % note.guid)
        print("note title -> %s " % note.title)
        print("note content hash -> %s " % note.contentHash)
        # get note content by guid
        content = noteStore.getNoteContent(dev_token, note.guid)
        print("note content -> %s" % content)

</pre>

- step 5: run and get exception

run YinxiangTest.py and get exception

<pre>
Traceback (most recent call last):
  File "/Users/jiangzhuolin/PycharmProjects/evernote-sdk-python3/sample/client/YinxiangTest.py", line 12, in <module>
    user = userStore.getUser()
  File "/Users/jiangzhuolin/PycharmProjects/evernote-sdk-python3/venv/lib/python3.7/site-packages/evernote3-1.25.0-py3.7.egg/evernote/api/client.py", line 167, in delegate_method
  File "/Users/jiangzhuolin/PycharmProjects/evernote-sdk-python3/venv/lib/python3.7/site-packages/evernote3-1.25.0-py3.7.egg/evernote/edam/userstore/UserStore.py", line 1033, in getUser
  File "/Users/jiangzhuolin/PycharmProjects/evernote-sdk-python3/venv/lib/python3.7/site-packages/evernote3-1.25.0-py3.7.egg/evernote/edam/userstore/UserStore.py", line 1058, in recv_getUser
evernote.edam.error.ttypes.EDAMSystemException: EDAMSystemException(message='authenticationToken', errorCode=8, rateLimitDuration=None)
</pre>

## root cause of bug

The root cause of this bug is if condition in evernote.api.client.py

this condition code is below, if sanbox parameter is True(that's a default value), variable of default_service_host is always 'sandbox.evernote.com'. But my sandbox token is applied from sandbox.yinxiang.com. So it's the root cause of this bug.

<pre>
class EvernoteClient(object):
    def __init__(self, **options):
        self.consumer_key = options.get('consumer_key')
        self.consumer_secret = options.get('consumer_secret')
        self.sandbox = options.get('sandbox', True)
        self.china = options.get('china', False)
        if self.sandbox:
            default_service_host = 'sandbox.evernote.com'
        elif self.china:
            default_service_host = 'app.yinxiang.com'
        else:
            default_service_host = 'www.evernote.com'
        self.service_host = options.get('service_host', default_service_host)
        self.additional_headers = options.get('additional_headers', {})
        self.token = options.get('token')
        self.secret = options.get('secret')
</pre>

![image](https://user-images.githubusercontent.com/10104887/85955818-f8a3f280-b9b3-11ea-9f76-c905ba1e0d07.png)

## fixed

fix logic bug both parameter of sandbox and china are True.

<pre>
class EvernoteClient(object):
    def __init__(self, **options):
        self.consumer_key = options.get('consumer_key')
        self.consumer_secret = options.get('consumer_secret')
        self.sandbox = options.get('sandbox', True)
        self.china = options.get('china', False)
        if self.sandbox:
            if self.china:
                default_service_host = 'sandbox.yinxiang.com'
            else:
                default_service_host = 'sandbox.evernote.com'
        else:
            if self.china:
                default_service_host = 'app.yinxiang.com'
            else:
                default_service_host = 'www.evernote.com'
        self.service_host = options.get('service_host', default_service_host)
        self.additional_headers = options.get('additional_headers', {})
        self.token = options.get('token')
        self.secret = options.get('secret')
</pre>


PS. I attempt to use `pip3 install evernote3` from pypi，but I found the same bug in the version 1.25.14. 


