### PR TITLE
Add dependency on oauth2 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     ],
     license='BSD',
     install_requires=[
+        'oauth2',
         'oauthlib',
         'requests_oauthlib'
     ],


### PR DESCRIPTION
`pip install evernote3` does not install `oauth2`, on which `evernote3` depends. This PR fixes this. 